### PR TITLE
Es lint File fixes for Shift Schedule and View Shift Card

### DIFF
--- a/src/components/ManagerComponents/shiftSchedule/ShiftSchedule.tsx
+++ b/src/components/ManagerComponents/shiftSchedule/ShiftSchedule.tsx
@@ -6,7 +6,6 @@
   2. Change how House is retrieved using new Danashi User Context. (Functional for now, plugging House context is a little buggy)
   3. styling
 */
-import { getUser } from '../../../firebase/queries/user'
 import React, { useEffect, useState } from 'react'
 import {
   Table,
@@ -16,16 +15,13 @@ import {
   TableHead,
   TableRow,
 } from '@mui/material'
-import { getHouse } from '../../../firebase/queries/houseQueries'
+import { getHouse } from '../../../firebase/queries/house'
 import { Day } from '../../../types/schema'
 import { getNumVerified, getShift } from '../../../firebase/queries/shift'
 import { Shift } from '../../../types/schema'
-import { type } from 'os'
 import Select from 'react-select'
-import { firestoreAutoId, objectToMap } from '../../../firebase/helpers'
 import Paper from '@mui/material/Paper'
 import { useUserContext } from '../../../context/UserContext'
-import ShiftCard from '../Shiftcard/Shiftcard'
 import AssignShiftcard from '../AssignShiftcard/AssignShiftcard'
 import styles from './ShiftSchedule.module.css'
 
@@ -42,7 +38,7 @@ import styles from './ShiftSchedule.module.css'
  * 6. In schedule, store table entries in based on which day they're from.
  */
 export const ShiftSchedule = () => {
-  const { authUser, house } = useUserContext()
+  const { authUser } = useUserContext()
 
   /* MOST IMPORTANT:  Holds the row components that are loaded onto the table
   Each k: Days, value: List of corresponding components matching a given shift*/
@@ -82,9 +78,8 @@ export const ShiftSchedule = () => {
   ]
 
   // For React Select, to dispay Day on dropdown (FRONTEND)
-  const [selectedDay, setSelectedDay] = useState<ValueType<OptionType>>(
-    dayOptions[0]
-  )
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const [selectedDay, setSelectedDay] = useState<any>(dayOptions[0])
 
   /**
    * @remarks
@@ -92,7 +87,7 @@ export const ShiftSchedule = () => {
    * must rerender the table rows to fit that day
    * @param option - From dayOptions
    */
-  const handleDayChange = (option: ValueType<any>) => {
+  const handleDayChange = (option: { value: string }) => {
     setSelectedDay(option)
     setDailyRows(schedule.get(option.value))
   }
@@ -115,17 +110,17 @@ export const ShiftSchedule = () => {
    * Loads the FB data and creates Row Components to display on MUI Table
    */
   const loadScheduleComponents = async () => {
-    let houseFB = await getHouse(authUser.houseID)
-    let tempSchedule = new Map<string, JSX.Element[]>()
+    const houseFB = await getHouse(authUser.houseID)
+    const tempSchedule = new Map<string, JSX.Element[]>()
     //Promise All is important here because we need all Data to be loaded in before setting schedule again.
     //houseFB.Schedule contains the FB schedule.
     Promise.all(
       Object.entries(houseFB.schedule).map(async (entry) => {
-        let day = entry[0],
+        const day = entry[0],
           shiftIDs = entry[1]
         //getDailyData converts all Firebase Shifts to row Data, only retrieves essential info for a row
-        let dailyData: rowData[] = await getDailyData(day, shiftIDs)
-        let rowComponents: JSX.Element[] = []
+        const dailyData: rowData[] = await getDailyData(day, shiftIDs)
+        const rowComponents: JSX.Element[] = []
         //Turn all row Data into Row Components
         convertDataToComponent(dailyData, rowComponents)
         tempSchedule.set(day, rowComponents)
@@ -152,14 +147,14 @@ export const ShiftSchedule = () => {
     if (shiftIDs == undefined) {
       return new Array<rowData>()
     }
-    let shiftPromises: Promise<Shift | undefined>[] = []
+    const shiftPromises: Promise<Shift | undefined>[] = []
     setCurrentShiftCardID(shiftIDs[0])
     shiftIDs.map((id) => {
       shiftPromises.push(getShift(authUser.houseID, id))
     })
     //MUST use Promise.all to assure that ALL shifts are loaded in before any loading is done.
-    let shiftObjects = await Promise.all(shiftPromises)
-    let numVerifiedPromises: Promise<number | undefined>[] = []
+    const shiftObjects = await Promise.all(shiftPromises)
+    const numVerifiedPromises: Promise<number | undefined>[] = []
     //Number Verified is retrieved differently since it's a collection.
     shiftObjects.map((shift) => {
       if (shift != undefined) {
@@ -168,16 +163,16 @@ export const ShiftSchedule = () => {
         )
       }
     })
-    let numVerifiedList = await Promise.all(numVerifiedPromises)
-    let rowObjects: rowData[] = []
+    const numVerifiedList = await Promise.all(numVerifiedPromises)
+    const rowObjects: rowData[] = []
     shiftObjects.map((shift, index) => {
-      let numVerified = numVerifiedList[index]
+      const numVerified = numVerifiedList[index]
       if (shift != undefined && numVerified != undefined) {
         /**
          * Since verified shifts aren't set up in firebase,
          * can put random numbers in numVerified to test that status bar works
          * */
-        let rowObject = createRowData(shift, numVerified)
+        const rowObject = createRowData(shift, numVerified)
         rowObjects.push(rowObject)
       }
     })
@@ -191,7 +186,7 @@ export const ShiftSchedule = () => {
    * @param numVerified - Number of verified shifts
    */
   const createRowData = (shiftFB: Shift, numVerified: number): rowData => {
-    var status
+    let status
     if (numVerified == 0) {
       status = 'Missing'
     } else if (shiftFB.numOfPeople > numVerified) {
@@ -212,23 +207,23 @@ export const ShiftSchedule = () => {
       if (time > 1230) {
         time = time - 1200
       }
-      let timeString = String(time)
+      const timeString = String(time)
       let hours
       if (timeString.length > 3) {
         hours = timeString.slice(0, 2)
       } else {
         hours = timeString.slice(0, 1)
       }
-      let minutes = timeString.slice(-2)
+      const minutes = timeString.slice(-2)
       if (minutes == '30') {
         return hours + ':' + minutes + meridian
       }
       return hours + meridian
     }
 
-    let startTime = parseTime(shiftFB.timeWindow[0])
-    let endTime = parseTime(shiftFB.timeWindow[1])
-    let timeWindow = startTime + ' - ' + endTime
+    const startTime = parseTime(shiftFB.timeWindow[0])
+    const endTime = parseTime(shiftFB.timeWindow[1])
+    const timeWindow = startTime + ' - ' + endTime
     return {
       name: shiftFB.name,
       shiftID: shiftFB.shiftID,
@@ -266,7 +261,7 @@ export const ShiftSchedule = () => {
 
   useEffect(() => {
     loadScheduleComponents()
-  }, [authUser])
+  })
 
   //ID that will be used for current Card modal.
   const [currentShiftCardID, setCurrentShiftCardID] = useState('')

--- a/src/components/MemberComponents/ViewShiftcard/ViewShiftcard.tsx
+++ b/src/components/MemberComponents/ViewShiftcard/ViewShiftcard.tsx
@@ -30,7 +30,9 @@ type ViewShiftcardProps = {
   shiftID: string
   houseID: string
   open: boolean
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   handleClose: any
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   handleOpen: any
 }
 
@@ -58,9 +60,10 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
   houseID,
   open,
   handleClose,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handleOpen,
 }: ViewShiftcardProps) => {
-  const { authUser, house } = useUserContext()
+  const { authUser } = useUserContext()
   const [shift, setShift] = useState<Shift | null>()
   const [memberRows, setMemberRows] = useState<JSX.Element[]>()
   const [verifierPin, setVerifierPin] = useState('')
@@ -76,7 +79,6 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
    * Verifying shift runs a check to assure that the verification is possible, if so, object is added to that collection.
    **/
   useEffect(() => {
-    const today = new Date()
     const getShiftFB = async () => {
       if (shiftID != '') {
         // greg: added this check for an empty shiftID cuz the default state in the MemberShiftView is an empty string
@@ -88,6 +90,8 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
       }
     }
     getShiftFB()
+    //disabling for this line because the suggested deps would cause an infinite loop, they're changed by the callback.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shiftID]) // greg: added this so that the modal grabbed the correct shift info based on the changing currentShiftCard value in MemberShiftView component
 
   /**
@@ -99,10 +103,10 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
    */
   const loadMemberRows = async (usersAssigned: string[]) => {
     console.log({ authUser: authUser })
-    let userObjects = await getAssignedUsers(usersAssigned)
-    let tempMemRows = new Array<JSX.Element>()
-    let verShifts = await getVerifiedShifts(houseID, shiftID)
-    let house = await getHouse(houseID)
+    const userObjects = await getAssignedUsers(usersAssigned)
+    const tempMemRows = new Array<JSX.Element>()
+    const verShifts = await getVerifiedShifts(houseID, shiftID)
+    const house = await getHouse(houseID)
     setUserPinMap(house.userPINs)
     //Uses list of Users to generate the member rows in table
     userObjects.map((user) => {
@@ -120,11 +124,12 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
    * @returns - List of Users assigned to shift
    */
   const getAssignedUsers = async (usersAssigned: string[]) => {
-    let promises: Promise<User | null>[] = []
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    const promises: Promise<any>[] = []
     usersAssigned.map((userID) => {
       promises.push(getUser(userID))
     })
-    let userObjects = await Promise.all(promises)
+    const userObjects = await Promise.all(promises)
     return userObjects
   }
 
@@ -149,10 +154,10 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
   ) => {
     let status = 'Incomplete'
     let time = ''
-    let verifiedShift = verShifts.get(user.userID)
-    let username = user.firstName + ' ' + user.lastName
-    let authname = authUser.firstName + ' ' + authUser.lastName
-    let name = username != authname ? username : 'me' //If member row is the current user, display name as 'me'
+    const verifiedShift = verShifts.get(user.userID)
+    const username = user.firstName + ' ' + user.lastName
+    const authname = authUser.firstName + ' ' + authUser.lastName
+    const name = username != authname ? username : 'me' //If member row is the current user, display name as 'me'
     console.log('Member: ', username, ' | VerifiedShift: ', verifiedShift)
     if (verifiedShift != undefined) {
       status = 'Complete'
@@ -194,7 +199,7 @@ const ViewShiftcard: React.FC<ViewShiftcardProps> = ({
    * If so, verifyShift is called which creates a verifyShift object in the firebase.
    */
   const handleVerify = () => {
-    let verifierID = userPinMap.get(verifierPin)
+    const verifierID = userPinMap.get(verifierPin)
     console.log({ userPinMap, verifierPin })
     if (verifierID == undefined) {
       //Replace with modal/warning

--- a/src/firebase/queries/house.ts
+++ b/src/firebase/queries/house.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// TODO: Remove the eslint disable once more of these funcs are used.
 import {
   collection,
   addDoc,
@@ -123,12 +125,12 @@ export const addCategory = async (
   if (colSnap.exists()) {
     const promise: Promise<House> = parseHouse(colSnap)
     const house = await promise
-    var houseCategories = house.categories
+    const houseCategories = house.categories
 
     //checks if category already exists, {} is nested
     if (!houseCategories?.has(newCategory)) {
       // Nested maps -> object
-      let newMap = new Map<string, object>()
+      const newMap = new Map<string, object>()
       houseCategories.forEach((value, key) => {
         newMap.set(key, mapToObject(value))
       })
@@ -177,7 +179,7 @@ export const updateCategory = async (
   if (colSnap.exists()) {
     const promise: Promise<House> = parseHouse(colSnap)
     const house = await promise
-    var houseCategories = objectToMap(house.categories)
+    const houseCategories = objectToMap(house.categories)
 
     //checks if shift is a valid shift object
     if (shift.name && shift.shiftID && shift.category) {
@@ -265,7 +267,7 @@ export const removeShiftFromCategory = async (
   if (colSnap.exists()) {
     const promise: Promise<House> = parseHouse(colSnap)
     const house = await promise
-    var houseCategories = objectToMap(house.categories)
+    const houseCategories = objectToMap(house.categories)
 
     //checks if shift is a valid shift object
     if (shift.name && shift.shiftID && shift.category) {
@@ -317,7 +319,7 @@ export const removeCategory = async (
   if (colSnap.exists()) {
     const promise: Promise<House> = parseHouse(colSnap)
     const house = await promise
-    var houseCategories = objectToMap(house.categories)
+    const houseCategories = objectToMap(house.categories)
 
     //checks if category exists
     if (houseCategories?.has(oldCategory)) {
@@ -336,6 +338,7 @@ export const removeCategory = async (
 }
 
 //parses house document passed in
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const parseHouse = async (doc: any) => {
   const data = doc.data()
   const houseID = doc.id.toString()
@@ -344,8 +347,8 @@ const parseHouse = async (doc: any) => {
   const categories = data.categories
   const schedule = data.schedule
   const userPINs = data.userPINs
-  let categMap = objectToMap(categories)
-  let newMap = new Map<string, Map<string, string>>()
+  const categMap = objectToMap(categories)
+  const newMap = new Map<string, Map<string, string>>()
   categMap.forEach((value, key) => {
     newMap.set(key, objectToMap(value))
   })


### PR DESCRIPTION
Note:  ESLINT disabled for certain props.  Shift-Schedule uses React-Select, which needs its selectable options to be an `any` type in order to function properly.  View Shift Card uses arrow functions for `HandleOpen` and `HandleClose` props, which can't be statically typed to `Function`, so must remain as `any` type.